### PR TITLE
add clarification and fix typo

### DIFF
--- a/_posts/2019-04-07-issue-75.md
+++ b/_posts/2019-04-07-issue-75.md
@@ -14,7 +14,7 @@ php-ext-wasm is an extension that allows you to run WebAssembly code from PHP. P
 
 <small>MEDIUM.COM</small>
 
-And yet more wasmer ... this post compares the performance of various 'back ends' including Dynamism (a newly added single-pass compiler), Cranelift and LLVM.
+And yet more wasmer ... this post compares the performance of various 'back ends' including a single-pass compiler (formerly named Dynasm), Cranelift and LLVM.
 
 ### [Transport Tycoon Deluxe (TTD) - Online](http://epicport.com/en/ttd)
 


### PR DESCRIPTION
This fixes a small harmless typo, and adds a clarification about the name of Dynasm compiler in Wasmer.

Unrelated: thank you so much wasmweekly for making this happen! The content is fantastic and the site looks great. I love this newsletter ❤️